### PR TITLE
Removing spaces at beginning of raw text may prevent a bug that was o…

### DIFF
--- a/src/tdc_assistant_gui_controller_v2/public_chat/scrape_public_chat.py
+++ b/src/tdc_assistant_gui_controller_v2/public_chat/scrape_public_chat.py
@@ -26,7 +26,7 @@ def scrape_public_chat_raw_text(control: Any) -> str:
     if result is None:
         raise Exception(ERR_MSG_CONTROL_NOT_FOUND)
 
-    return result
+    return result.strip()
 
 
 def scrape_public_chat(


### PR DESCRIPTION
…ccurring due to leading spaces replaced by other characters in follow-up scrapes